### PR TITLE
Fix error in transact_raw function

### DIFF
--- a/pettycash/views.py
+++ b/pettycash/views.py
@@ -145,7 +145,10 @@ def transact_raw(
         )
         logger.info("payment: %s" % reason)
         tx._change_reason = reason[:100]
-        tx.save(is_privileged=request.user.is_privileged)
+        if request.user.is_authenticated:
+            tx.save(is_privileged=request.user.is_privileged)
+        else:
+            tx.save()
         if sent_alert:
             alertOwnersToChange(tx, user, [])
 


### PR DESCRIPTION
Following log happens in production:

`pettycash.views: Unexpected error during initial (raw) save of new pettycash: 'AnonymousUser' object has no attribute 'is_privileged'`

This was traced back to the function `transact_raw` in `pettycash/views.py`. It seems this function is sometimes called from an AnonymousUser object, which seems to be due to the fact that the function `api2_pay` in `pettycash/views.py` calls it (which has no decorator forcing the user to be logged in). The fix is to check if the user is authenticated before saving with `is_privileged` as an argument. This might not be intended behavior, but it will at least fix the issue in production.