### PR TITLE
fix: missing space character in service log email subject

### DIFF
--- a/servicelog/templates/email_notification_subject.txt
+++ b/servicelog/templates/email_notification_subject.txt
@@ -1,1 +1,1 @@
-{% autoescape off %}[spacebot] {{ machine }} was {%if machine.out_of_order %}taken out of {% else %}put back into{% endif %}service.{% endautoescape %}
+{% autoescape off %}[spacebot] {{ machine }} was {%if machine.out_of_order %}taken out of {% else %}put back into {% endif %}service.{% endautoescape %}


### PR DESCRIPTION
* Before: `[deelnemers] [spacebot] Abene Metal Mill was put back intoservice.`
* After: `[deelnemers] [spacebot] Abene Metal Mill was put back into service.`