### PR TITLE
fix: adds a fallback title value

### DIFF
--- a/makerspaceleiden/settings.py
+++ b/makerspaceleiden/settings.py
@@ -80,6 +80,7 @@ INSTALLED_APPS = [
 ]
 
 SITE_ID = 1
+SITE_NAME = "Makerspace Leiden"
 
 MIDDLEWARE = [
     "simple_history.middleware.HistoryRequestMiddleware",
@@ -122,6 +123,7 @@ SETTINGS_EXPORT = [
     "NONE_ID",
     "NONE_LABEL",
     "TRUSTEES",
+    "SITE_NAME",
 ]
 
 # WSGI_APPLICATION = "makerspaceleiden.wsgi.application"

--- a/makerspaceleiden/templates/base.html
+++ b/makerspaceleiden/templates/base.html
@@ -8,7 +8,7 @@
 <html lang="{{ LANGUAGE_CODE|default:"en-us" }}" {% if LANGUAGE_BIDI %}dir="rtl"{% endif %}>
 
 <head>
-    <title>{% block title %}{% endblock %}</title>
+    <title>{% block title %}Intranet{% endblock %} – {{ settings.SITE_NAME }}</title>
 
     <link rel="stylesheet" type="text/css" href="{% block stylesheet_base %}{% static "admin/css/base.css" %}{% endblock %}">
     <link rel="stylesheet" type="text/css" href="{% block stylesheet_custom %}{% static "makerspaceleiden/css/styles.css" %}{% endblock %}">
@@ -41,7 +41,7 @@
                         <div class="col">
                             {% block branding %}
                             <div class= "branding makerspace-name-div">
-                                <a class="makerspace-name" href="{% url 'index' %}">Makerspace Leiden</a>
+                                <a class="makerspace-name" href="{% url 'index' %}">{{ settings.SITE_NAME }}</a>
                                 <div class="d-block d-md-none">
                                     <b>INTRANET</b>
                                 </div>

--- a/makerspaceleiden/tests.py
+++ b/makerspaceleiden/tests.py
@@ -1,0 +1,24 @@
+from unittest import TestCase
+
+from django.conf import settings
+from django.test import Client
+
+
+class MakerspaceleidenTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def test_homepage(self):
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            "Intranet – " + settings.SITE_NAME, response.content.decode("utf-8")
+        )
+
+    def test_login(self):
+        response = self.client.get("/login/")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            "<title>Login – " + settings.SITE_NAME + "</title>",
+            response.content.decode("utf-8"),
+        )

--- a/selfservice/templates/registration/login.html
+++ b/selfservice/templates/registration/login.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block title %}Login{% endblock %}
+
 {% load i18n static %}
 
 {% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/login.css" %}">


### PR DESCRIPTION
Before this change the `<title></title>` element was
typically empty as no views currently use the title
block, resulting the URL being displayed
in the top of the browser.

The changes here
* Ensure there is a fallback if the title block has not
 been populated by the current view.
* Add title block to Login template
* Validate desired behaviour using tests

Whilst I have introduced automated tests here primarily to satisfy my own curiousity with the Django testing tools, I consciously choose **not** to include a GitHub action that runs those tests. I am more than happy to do this if folks are open to it. I appreciate that this is volunteer software, so has different requirements to paid work, but I consider tests as invaluable documentation for communicating intent. 