### PR TITLE
feat(agenda): add ability to copy agenda items

### DIFF
--- a/agenda/templates/agenda/agenda.html
+++ b/agenda/templates/agenda/agenda.html
@@ -20,9 +20,9 @@
 
                 {% if selected_item %}
                     <div class="row">
-                        <div class="col-md pb-2 pt-1" style="font-weight:600; font-size: 1.1em">
+                        <h2 class="col-md pb-2 pt-0 mt-0">
                             {{ selected_item.item_title }}
-                        </div>
+                        </h2>
                     </div>
                     <div class="row">
                         <div class="col-xl-1 col-lg-2 col-12" style="font-weight:600;">
@@ -50,13 +50,24 @@
                         </div>
                         <div class="row row-sticky-bottom">
 
-                            <div class="creation-info">
+                            <div class="creation-info d-flex justify-content-between align-items-center">
                                 <small>
                                     Created: {{ creation_date|date:"l j M Y H:i" }} by
                                     <a href="{{created_by.path}}">
                                         {{ created_by.first_name }}
                                     </a>
                                 </small>
+
+                                <div class="col-auto pe-0">
+                                    <a href="{% url 'agenda_update' selected_item.pk %}"
+                                        class="btn btn-outline-secondary btn-sm">
+                                        Edit
+                                    </a>
+                                    <a href="{% url 'agenda_create' %}?copy_from={{ selected_item.id }}"
+                                        class="btn btn-outline-secondary btn-sm">
+                                        Copy
+                                    </a>
+                                </div>
                             </div>
                             {% if is_updated %}
                                 <div class="update-info">
@@ -68,9 +79,9 @@
                                     </small>
                                 </div>
                             {% endif %}
-
                         </div>
                     {% endif %}
+
                 {% else %}
                     <small>No upcoming events</small>
                 {% endif %}
@@ -81,11 +92,6 @@
                 <div class="col-auto pe-0">
                     <button type="button" onclick="window.location.href='{% url 'index' %}'" class="btn btn-secondary">Back</button>
                 </div>
-                {% if selected_item %}
-                <div class="col-auto pe-0">
-                    <button type="button" onclick="window.location.href='{% url 'agenda_update' selected_item.pk %}'" class="btn btn-primary btn-primary-custom">Edit</button>
-                </div>
-                {% endif %}
                 <div class="col-auto">
                     <button type="button" onclick="window.location.href='{% url 'agenda_create' %}'" class="btn btn-primary btn-primary-custom">Create New</button>
                 </div>

--- a/agenda/tests.py
+++ b/agenda/tests.py
@@ -1,1 +1,91 @@
-# Create your tests here.
+from datetime import date, datetime, time
+
+import time_machine
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+
+from acl.models import User
+from agenda.models import Agenda
+
+
+class AgendaCreateViewTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            first_name="An",
+            last_name="Example",
+            password="testpassword",
+            email="example@example.com",
+        )
+        success = self.client.login(email=self.user.email, password="testpassword")
+        self.assertTrue(success)
+
+    def test_agenda_create_get(self):
+        url = reverse("agenda_create")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTemplateUsed(response, "agenda/agenda_crud.html")
+
+    def test_agenda_view(self):
+        url = reverse("agenda_detail", kwargs={"pk": 1})
+
+        original = Agenda.objects.create(
+            startdate=date.today(),
+            starttime=time(9, 0),
+            enddate=date.today(),
+            endtime=time(10, 0),
+            item_title="Fixture Agenda Title",
+            item_details="This is a fixture agenda item for testing.",
+            user=self.user,
+        )
+
+        response = self.client.get(url + "?copy_from=1")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        html = response.content.decode("utf-8")
+        self.assertTemplateUsed(response, "agenda/agenda.html")
+        self.assertIn(original.item_title, html)
+        self.assertIn(original.item_details, html)
+
+    @time_machine.travel("2025-05-10 14:56")
+    def test_agenda_create_copy_from(self):
+        url = reverse("agenda_create")
+
+        original = Agenda.objects.create(
+            startdate=date.today(),
+            starttime=time(9, 0),
+            enddate=date.today(),
+            endtime=time(10, 0),
+            item_title="Fixture Agenda Title",
+            item_details="This is a fixture agenda item for testing.",
+            user=self.user,
+        )
+
+        response = self.client.get(url + "?copy_from=1")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        html = response.content.decode("utf-8")
+        self.assertTemplateUsed(response, "agenda/agenda_crud.html")
+        self.assertIn(original.item_title, html)
+        self.assertIn(original.item_details, html)
+        self.assertIn("2025-05-17", html, "Suggested dates")
+
+    @time_machine.travel("2025-05-05 14:56")
+    def test_agenda_create_copy_from_on_a_saturday(self):
+        url = reverse("agenda_create")
+
+        original = Agenda.objects.create(
+            startdate=datetime.strptime("2025-05-03", "%Y-%m-%d").date(),
+            starttime=time(9, 0),
+            enddate=datetime.strptime("2025-05-03", "%Y-%m-%d").date(),
+            endtime=time(10, 0),
+            item_title="Fixture Agenda Title",
+            item_details="This is a fixture agenda item for testing.",
+            user=self.user,
+        )
+
+        response = self.client.get(url + "?copy_from=1")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        html = response.content.decode("utf-8")
+        self.assertTemplateUsed(response, "agenda/agenda_crud.html")
+        self.assertIn(original.item_title, html)
+        self.assertIn(original.item_details, html)
+        self.assertIn("2025-05-10", html, "Suggested dates")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "pycryptodome>=3.22.0",
     "django-sendmail-backend>=0.1.2",
     "django-oauth-toolkit>=3.0.1",
+    "time-machine>=2.16.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -657,6 +657,7 @@ dependencies = [
     { name = "reportlab" },
     { name = "requests" },
     { name = "six" },
+    { name = "time-machine" },
     { name = "websockets" },
     { name = "wheel" },
 ]
@@ -703,6 +704,7 @@ requires-dist = [
     { name = "reportlab", specifier = ">=4.0.7,<5" },
     { name = "requests", specifier = ">=2.32.2,<3" },
     { name = "six", specifier = ">=1.16.0,<2" },
+    { name = "time-machine", specifier = ">=2.16.0" },
     { name = "websockets", specifier = "~=12.0" },
     { name = "wheel", specifier = ">=0.42.0,<0.43" },
 ]
@@ -1205,6 +1207,28 @@ xlsx = [
 ]
 yaml = [
     { name = "pyyaml" },
+]
+
+[[package]]
+name = "time-machine"
+version = "2.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/dd/5022939b9cadefe3af04f4012186c29b8afbe858b1ec2cfa38baeec94dab/time_machine-2.16.0.tar.gz", hash = "sha256:4a99acc273d2f98add23a89b94d4dd9e14969c01214c8514bfa78e4e9364c7e2", size = 24626, upload-time = "2024-10-08T14:21:59.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/18/3087d0eb185cedbc82385f46bf16032ec7102a0e070205a2c88c4ecf9952/time_machine-2.16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7751bf745d54e9e8b358c0afa332815da9b8a6194b26d0fd62876ab6c4d5c9c0", size = 20209, upload-time = "2024-10-08T14:21:34.222Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a3/fcc3eaf69390402ecf491d718e533b6d0e06d944d77fc8d87be3a2839102/time_machine-2.16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1784edf173ca840ba154de6eed000b5727f65ab92972c2f88cec5c4d6349c5f2", size = 16681, upload-time = "2024-10-08T14:21:35.14Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/96/8b76d264014bf9dc21873218de50d67223c71736f87fe6c65e582f7c29ac/time_machine-2.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f5876a5682ce1f517e55d7ace2383432627889f6f7e338b961f99d684fd9e8d", size = 33768, upload-time = "2024-10-08T14:21:36.942Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/13/59ae8259be02b6c657ef6e3b6952bf274b43849f6f35cc61a576c68ce301/time_machine-2.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:806672529a2e255cd901f244c9033767dc1fa53466d0d3e3e49565a1572a64fe", size = 31685, upload-time = "2024-10-08T14:21:37.881Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c1/9f142beb4d373a2a01ebb58d5117289315baa5131d880ec804db49e94bf7/time_machine-2.16.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:667b150fedb54acdca2a4bea5bf6da837b43e6dd12857301b48191f8803ba93f", size = 33447, upload-time = "2024-10-08T14:21:38.809Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f7/ed9ecd93c2d38dca77d0a28e070020f3ce0fb23e0d4a6edb14bcfffa5526/time_machine-2.16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:da3ae1028af240c0c46c79adf9c1acffecc6ed1701f2863b8132f5ceae6ae4b5", size = 33408, upload-time = "2024-10-08T14:21:39.785Z" },
+    { url = "https://files.pythonhosted.org/packages/91/40/d0d274d70fa2c4cad531745deb8c81346365beb0a2736be05a3acde8b94a/time_machine-2.16.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:520a814ea1b2706c89ab260a54023033d3015abef25c77873b83e3d7c1fafbb2", size = 31526, upload-time = "2024-10-08T14:21:40.769Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ba/a27cdbb324d9a6d779cde0d514d47b696b5a6a653705d4b511fd65ef1514/time_machine-2.16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8243664438bb468408b29c6865958662d75e51f79c91842d2794fa22629eb697", size = 33042, upload-time = "2024-10-08T14:21:41.722Z" },
+    { url = "https://files.pythonhosted.org/packages/72/63/64e9156c9e38c18720d0cc41378168635241de44013ffe3dd5b099447eb0/time_machine-2.16.0-cp313-cp313-win32.whl", hash = "sha256:32d445ce20d25c60ab92153c073942b0bac9815bfbfd152ce3dcc225d15ce988", size = 19108, upload-time = "2024-10-08T14:21:43.596Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/40/27f5738fbd50b78dcc0682c14417eac5a49ccf430525dd0c5a058be125a2/time_machine-2.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:f6927dda86425f97ffda36131f297b1a601c64a6ee6838bfa0e6d3149c2f0d9f", size = 19935, upload-time = "2024-10-08T14:21:45.277Z" },
+    { url = "https://files.pythonhosted.org/packages/35/75/c4d8b2f0fe7dac22854d88a9c509d428e78ac4bf284bc54cfe83f75cc13b/time_machine-2.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:4d3843143c46dddca6491a954bbd0abfd435681512ac343169560e9bab504129", size = 18047, upload-time = "2024-10-08T14:21:46.261Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Enhances the agenda interface with several improvements:

### New Copy Feature
- **Copy functionality**: Added ability to copy existing agenda items with smart date suggestions
- **Suggested date calculation**: When copying, the system picks the next occurrence of the same weekday as the original event
- **Preserved timing**: Maintains the same time slots and duration when copying events

### UI Changes
- **Better title styling**: Changed agenda item titles from styled divs to proper `<h2>` elements for better semantic structure
- **Improved layout**: Added flexbox layout to creation info section with Edit/Copy buttons positioned on the right
- **Button reorganization**: Moved Edit button from bottom action bar to inline with creation info for better UX

### Technical Improvements
- **Helper functions**: Added `get_next_occurrence_of_weekday()` and `get_suggested_dates_for_copy()` utility functions
- **Enhanced form handling**: Updated `AgendaCreateView` to handle `copy_from` parameter and pre-populate form fields
- **Comprehensive testing**: Added test suite covering copy functionality with time-based scenarios using `time-machine` library
- **Dependency addition**: Added `time-machine>=2.16.0` for reliable time-based testing

The changes improve user experience by making it easier to create recurring events while maintaining a cleaner, more intuitive interface.

<img width="871" height="459" alt="Adds new copy button to the agenda view" src="https://github.com/user-attachments/assets/0e847f41-e434-4069-b77d-55f08ce45990" />
<img width="1151" height="606" alt="Create form is pre-populated with new dates and previous title and description" src="https://github.com/user-attachments/assets/02afdc71-f08a-4e63-ba0d-635bd9977f1a" />
