### PR TITLE
feat: drop machine info from State of Space

### DIFF
--- a/selfservice/templates/space_state.html
+++ b/selfservice/templates/space_state.html
@@ -42,38 +42,5 @@
 <i>There's no one at the space now.</i>
 {% endif %}
 
-{% if machines_on %}
-<h2>Machines currently in use</h2>
-  <table>
-    <tbody>
-      {% for machine_state in machines_on %}
-      <tr>
-        <td><b><a href="{% url 'machine_overview' machine_id=machine_state.machine.machine_id %}">{{ machine_state.machine.name }}</a></b></td>
-        <td>{{ machine_state.ts_human }}</i></td>
-        <td><i>{{ machine_state.ts }}</i></td>
-        <td>
-          <b><a href="{% url 'overview' member_id=machine_state.user.user_id %}">{{ machine_state.user.full_name }}</a></b>
-        </td>
-      </tr>
-      {% endfor %}
-    </tbody>
-
-  </table>
-{% endif %}
-
-
-<h2>Machines</h2>
-<table>
-  <tbody>
-    {% for machine_state in machines %}
-      <tr>
-        <td><b><a href="{% url 'machine_overview' machine_id=machine_state.machine.machine_id %}">{{ machine_state.machine.name }}</a></b></td>
-        <td>{{ machine_state.machine.location_name }}</td>
-        <td>{{ machine_state.state }}</td>
-      </tr>
-    {% endfor %}
-  </tbody>
-</table>
-
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
We already have this information available from
Node-RED and available at:
https://mijn.makerspaceleiden.nl/dashboard_intranet/nodered_active_machines/

This change removes duplication from the UI