### PR TITLE
fix(front-page): mobile badge appearance

### DIFF
--- a/selfservice/templates/index.html
+++ b/selfservice/templates/index.html
@@ -24,7 +24,7 @@ function toggle() {
 				<div class="list-group">
 					{% for event in agenda_items %}
 					<a href="{% url 'agenda_detail' pk=event.pk %}" class="list-group-item list-group-item-action py-3">
-						<div class="w-100 d-flex justify-content-between">
+						<div class="w-100 d-flex justify-content-between align-items-start">
 							<h4 class="my-0">
 								<span class="d-inline-block me-1">
 									{{ event.display_datetime }}


### PR DESCRIPTION
The `Help Wanted` badge is incorrectly stretching to fill available Y height on mobile layout

**Before**
<img width="391" height="686" alt="Screenshot 2025-10-18 at 20 09 09" src="https://github.com/user-attachments/assets/43fbca8b-aedc-4935-81de-d0a84f879d77" />

**After**
<img width="376" height="667" alt="Screenshot 2025-10-18 at 20 41 21" src="https://github.com/user-attachments/assets/cfdb8598-8110-4aaa-89aa-74d0ac0c41aa" />
